### PR TITLE
Add async CRUD endpoints for item model

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,9 +1,77 @@
-from fastapi import APIRouter
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db.session import async_session
+from ..models import Item
+from .schemas.item import ItemCreate, ItemRead, ItemUpdate
 
 router = APIRouter()
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Provide a transactional scope around a series of operations."""
+    async with async_session() as session:
+        yield session
 
 
 @router.get("/")
 async def read_root() -> dict[str, str]:
     """Root API endpoint."""
     return {"message": "Welcome to mp API"}
+
+
+@router.post("/items", response_model=ItemRead)
+async def create_item(
+    item: ItemCreate, session: AsyncSession = Depends(get_session)
+) -> ItemRead:
+    """Create a new item."""
+    db_item = Item(**item.dict())
+    session.add(db_item)
+    await session.commit()
+    await session.refresh(db_item)
+    return db_item
+
+
+@router.get("/items/{item_id}", response_model=ItemRead)
+async def get_item(
+    item_id: int, session: AsyncSession = Depends(get_session)
+) -> ItemRead:
+    """Retrieve a single item by ID."""
+    result = await session.execute(select(Item).where(Item.id == item_id))
+    db_item = result.scalar_one_or_none()
+    if db_item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return db_item
+
+
+@router.put("/items/{item_id}", response_model=ItemRead)
+async def update_item(
+    item_id: int, item: ItemUpdate, session: AsyncSession = Depends(get_session)
+) -> ItemRead:
+    """Update an existing item."""
+    result = await session.execute(select(Item).where(Item.id == item_id))
+    db_item = result.scalar_one_or_none()
+    if db_item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    for field, value in item.dict(exclude_unset=True).items():
+        setattr(db_item, field, value)
+    await session.commit()
+    await session.refresh(db_item)
+    return db_item
+
+
+@router.delete("/items/{item_id}")
+async def delete_item(
+    item_id: int, session: AsyncSession = Depends(get_session)
+) -> dict[str, bool]:
+    """Delete an item by ID."""
+    result = await session.execute(select(Item).where(Item.id == item_id))
+    db_item = result.scalar_one_or_none()
+    if db_item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    await session.delete(db_item)
+    await session.commit()
+    return {"ok": True}

--- a/app/api/schemas/item.py
+++ b/app/api/schemas/item.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+
+class ItemBase(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class ItemCreate(ItemBase):
+    """Schema for creating an item."""
+
+
+class ItemUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+
+
+class ItemRead(ItemBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .item import Item
+
+__all__ = ["Item"]

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..db.base import Base
+
+
+class Item(Base):
+    """Simple item model."""
+
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)


### PR DESCRIPTION
## Summary
- define SQLAlchemy `Item` model
- add Pydantic schemas for item input/output
- implement async CRUD routes using database session dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68924e2d9de0832c9818763104a165d8