### PR TITLE
feat(scraping): add async persistence pipeline

### DIFF
--- a/app/scraping/pipelines.py
+++ b/app/scraping/pipelines.py
@@ -1,0 +1,11 @@
+from sqlalchemy import text
+
+from ..db.session import async_session
+
+
+async def save_item(data: dict) -> None:
+    """Persist scraped item in the database using async_session."""
+    query = text("INSERT INTO scraped_data (title) VALUES (:title)")
+    async with async_session() as session:
+        await session.execute(query, {"title": data["title"]})
+        await session.commit()

--- a/app/scraping/sample_spider.py
+++ b/app/scraping/sample_spider.py
@@ -1,4 +1,11 @@
+import logging
+
 import scrapy
+
+from .pipelines import save_item
+
+
+logging.basicConfig(level=logging.INFO)
 
 
 class SampleSpider(scrapy.Spider):
@@ -6,8 +13,12 @@ class SampleSpider(scrapy.Spider):
 
     def start_requests(self):
         """Generate initial requests."""
+        self.logger.info("Starting requests")
         yield scrapy.Request("https://example.com", callback=self.parse)
 
-    def parse(self, response):
-        """Parse the response and return the page title."""
-        yield {"title": response.css("title::text").get()}
+    async def parse(self, response):
+        """Parse the response and persist the page title."""
+        data = {"title": response.css("title::text").get()}
+        await save_item(data)
+        self.logger.info("Saved item: %s", data)
+        yield data


### PR DESCRIPTION
## Summary
- persist scraped data using async SQLAlchemy session
- log sample spider activity

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68924e3c0030832c8664cbbb6f13e0b5