### PR TITLE
Add tests for authentication, API CRUD, and task execution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.base import Base
+
+
+@pytest.fixture(scope="module")
+def app_instance():
+    """Provide the FastAPI application instance."""
+    return app
+
+
+@pytest.fixture(scope="module")
+def db_session():
+    """Create an in-memory SQLite database for testing."""
+    engine = create_engine("sqlite:///:memory:", echo=False)
+    TestingSession = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSession()
+    yield session
+    session.close()
+    engine.dispose()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,42 @@
+import asyncio
+from sqlalchemy import Column, Integer, String
+
+from app.db.base import Base
+from app.api.routes import read_root
+from app.main import health_check
+
+
+class Item(Base):
+    __tablename__ = "items"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+
+
+def test_read_root(app_instance) -> None:
+    response = asyncio.run(read_root())
+    assert response == {"message": "Welcome to mp API"}
+
+
+def test_health_check(app_instance) -> None:
+    response = asyncio.run(health_check())
+    assert response == {"status": "ok"}
+
+
+def test_crud_operations(db_session) -> None:
+    item = Item(name="test")
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(item)
+    assert item.id is not None
+
+    fetched = db_session.get(Item, item.id)
+    assert fetched.name == "test"
+
+    fetched.name = "updated"
+    db_session.commit()
+    db_session.refresh(fetched)
+    assert fetched.name == "updated"
+
+    db_session.delete(fetched)
+    db_session.commit()
+    assert db_session.get(Item, item.id) is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,8 @@
+from app.auth.security import get_password_hash, verify_password
+
+
+def test_password_hashing() -> None:
+    password = "secret"
+    hashed = get_password_hash(password)
+    assert verify_password(password, hashed)
+    assert not verify_password("wrong", hashed)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,11 @@
+from app.tasks.worker import celery_app, example_task
+
+
+def test_example_task_execution() -> None:
+    celery_app.conf.update(
+        broker_url="memory://",
+        result_backend="cache+memory://",
+        task_always_eager=True,
+    )
+    result = example_task.delay()
+    assert result.get(timeout=10) == "task completed"


### PR DESCRIPTION
## Summary
- add pytest fixtures for app and in-memory SQLite database
- test password hashing and verification
- exercise API routes and CRUD operations
- verify Celery task execution with eager settings

## Testing
- `pytest tests/test_auth.py tests/test_api.py tests/test_tasks.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68924e41e3a8832c995a0789a1bfea0a