### PR TITLE
Fix test failures by deferring Item import and add example Celery task

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,7 +10,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db.session import async_session
-from ..models import Item
 from .schemas.item import ItemCreate, ItemRead, ItemUpdate
 
 
@@ -84,6 +83,8 @@ async def create_item(
     item: ItemCreate, session: AsyncSession = Depends(get_session)
 ) -> ItemRead:
     """Create a new item."""
+    from ..models import Item
+
     db_item = Item(**item.dict())
     session.add(db_item)
     await session.commit()
@@ -96,6 +97,8 @@ async def get_item(
     item_id: int, session: AsyncSession = Depends(get_session)
 ) -> ItemRead:
     """Retrieve a single item by ID."""
+    from ..models import Item
+
     result = await session.execute(select(Item).where(Item.id == item_id))
     db_item = result.scalar_one_or_none()
     if db_item is None:
@@ -108,6 +111,8 @@ async def update_item(
     item_id: int, item: ItemUpdate, session: AsyncSession = Depends(get_session)
 ) -> ItemRead:
     """Update an existing item."""
+    from ..models import Item
+
     result = await session.execute(select(Item).where(Item.id == item_id))
     db_item = result.scalar_one_or_none()
     if db_item is None:
@@ -124,6 +129,8 @@ async def delete_item(
     item_id: int, session: AsyncSession = Depends(get_session)
 ) -> dict[str, bool]:
     """Delete an item by ID."""
+    from ..models import Item
+
     result = await session.execute(select(Item).where(Item.id == item_id))
     db_item = result.scalar_one_or_none()
     if db_item is None:

--- a/app/tasks/worker.py
+++ b/app/tasks/worker.py
@@ -50,3 +50,9 @@ celery_app.conf.beat_schedule = {
 }
 
 celery_app.conf.timezone = "UTC"
+
+
+@celery_app.task
+def example_task() -> str:
+    """Simple example task used for testing."""
+    return "task completed"


### PR DESCRIPTION
## Summary
- Avoid SQLAlchemy table redefinition by importing `Item` lazily within route functions
- Add `example_task` Celery task returning `"task completed"`

## Testing
- `pytest tests/test_tasks.py::test_example_task_execution -q`
- `pytest tests/test_api.py::test_crud_operations -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689254073858832c87f3505cbbabf540